### PR TITLE
showErrors and get project info improvements.

### DIFF
--- a/BlenderRenderController/BlenderRenderController/BlenderRenderController.csproj
+++ b/BlenderRenderController/BlenderRenderController/BlenderRenderController.csproj
@@ -131,6 +131,9 @@
     <EmbeddedResource Include="ui\ErrorBox.resx">
       <DependentUpon>ErrorBox.cs</DependentUpon>
     </EmbeddedResource>
+    <None Include="..\..\README.md">
+      <Link>README.md</Link>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/BlenderRenderController/BlenderRenderController/Helper.cs
+++ b/BlenderRenderController/BlenderRenderController/Helper.cs
@@ -35,42 +35,71 @@ namespace BlenderRenderController
             RegsterLog();
 
             var errorText = "";
+
             foreach (var errorCode in errorCodes)
-            {
-                if(errorCode == AppErrorCodes.BLENDER_PATH_NOT_SET)
-                {
-                    errorText += $"Please set correct path to Blender ({new AppSettings().BlenderExeName}).\n";
-                }
-                if (errorCode == AppErrorCodes.FFMPEG_PATH_NOT_SET)
-                {
-                    errorText += $"Please set correct path to FFmpeg ({new AppSettings().FFmpegExeName}).\n";
-                }
-                if (errorCode == AppErrorCodes.BLEND_FILE_NOT_EXISTS)
-                {
-                    errorText += "File does not exists anymore.\n";
-                    errorText += "It was removed from the list of recent blends.\n";
-                }
-                if (errorCode == AppErrorCodes.RENDER_FORMAT_IS_IMAGE)
-                {
-                    errorText += "The render format is " + arg1 + " image.\n";
-                    errorText += "You can render an image sequence with this tool but you will need to make a video with other SW.\n";
-                }
-                if (errorCode == AppErrorCodes.BLEND_OUTPUT_INVALID)
-                {
-                    errorText += "Unable to read output path, using project location.";
-                }
-                if (errorCode == AppErrorCodes.UNKNOWN_OS)
-                {
-                    errorText += "Could not identify operating system, BRC might not work properly.";
-                }
-            }
+                errorText += SetErrorText(errorCode, arg1);
+
             MessageBox.Show(
                     errorText,
                     "",
                     MessageBoxButtons.OK,
                     icon);
+
             _log.Warn("-Helper- " + errorText);
         }
+
+        static public void showErrors(string errorCode, MessageBoxIcon icon = MessageBoxIcon.Asterisk, string arg1 = "")
+        {
+            RegsterLog();
+
+            var errorText = "";
+
+            errorText += SetErrorText(errorCode, arg1);
+
+            MessageBox.Show(
+                errorText,
+                "",
+                MessageBoxButtons.OK,
+                icon);
+
+            _log.Warn("-Helper- " + errorText);
+        }
+
+        static private string SetErrorText(string code, string arg1)
+        {
+            var errorText = "";
+            var appSettings = new AppSettings();
+
+            if (code == AppErrorCodes.BLENDER_PATH_NOT_SET)
+            {
+                errorText += $"Please set correct path to Blender ({appSettings.BlenderExeName}).\n";
+            }
+            if (code == AppErrorCodes.FFMPEG_PATH_NOT_SET)
+            {
+                errorText += $"Please set correct path to FFmpeg ({appSettings.FFmpegExeName}).\n";
+            }
+            if (code == AppErrorCodes.BLEND_FILE_NOT_EXISTS)
+            {
+                errorText += "File does not exists anymore.\n";
+                errorText += "It was removed from the list of recent blends.\n";
+            }
+            if (code == AppErrorCodes.RENDER_FORMAT_IS_IMAGE)
+            {
+                errorText += "The render format is " + arg1 + " image.\n";
+                errorText += "You can render an image sequence with this tool but you will need to make a video with other SW.\n";
+            }
+            if (code == AppErrorCodes.BLEND_OUTPUT_INVALID)
+            {
+                errorText += "Unable to read output path, using project location.";
+            }
+            if (code == AppErrorCodes.UNKNOWN_OS)
+            {
+                errorText += "Could not identify operating system, BRC might not work properly.";
+            }
+
+            return errorText;
+        }
+
         static public string fixPath(string path)
         {
             var fixedPath = path.Trim().TrimEnd('\\');

--- a/BlenderRenderController/BlenderRenderController/MainForm.cs
+++ b/BlenderRenderController/BlenderRenderController/MainForm.cs
@@ -328,8 +328,6 @@ namespace BlenderRenderController
                  loadBlend();
              }
              */
-            // initialize logger service
-
         }
 
         private void blendFileBrowseButton_Click(object sender, EventArgs e)
@@ -729,9 +727,8 @@ namespace BlenderRenderController
                 if (appState == AppStates.RENDERING_ALL && (p.afterRenderAction == AppStrings.AFTER_RENDER_JOIN_MIXDOWN || p.afterRenderAction == AppStrings.AFTER_RENDER_JOIN))
                 {
                     if (p.afterRenderAction == AppStrings.AFTER_RENDER_JOIN_MIXDOWN)
-                    {
                         mixdown();
-                    }
+
                     concatenate();
                     stopRender(true);
 
@@ -740,18 +737,14 @@ namespace BlenderRenderController
                            MessageBoxButtons.YesNo,
                            MessageBoxIcon.Question);
                     if (openOutputFolderQuestion == DialogResult.Yes)
-                    {
                         openOutputFolder();
-                    }
-                } else
-                {
-                    stopRender(true);
                 }
+                else
+                    stopRender(true);
             }
             else
-            {
                 stopRender(false);
-            }
+
             updateCurrentChunkStartEnd();
             updateUI();
         }
@@ -850,7 +843,6 @@ namespace BlenderRenderController
             catch (Exception ex)
             {
                 Trace.WriteLine(ex);
-                //oldLogger.add(ex.ToString());
                 _log.Error(ex.ToString());
                 Helper.showErrors(new List<string> { AppErrorCodes.FFMPEG_PATH_NOT_SET });
                 settingsForm.ShowDialog();

--- a/BlenderRenderController/BlenderRenderController/MainForm.cs
+++ b/BlenderRenderController/BlenderRenderController/MainForm.cs
@@ -844,7 +844,7 @@ namespace BlenderRenderController
             {
                 Trace.WriteLine(ex);
                 _log.Error(ex.ToString());
-                Helper.showErrors(new List<string> { AppErrorCodes.FFMPEG_PATH_NOT_SET });
+                Helper.showErrors(AppErrorCodes.FFMPEG_PATH_NOT_SET);
                 settingsForm.ShowDialog();
                 statusLabel.Text = "Joining cancelled.";
                 return;
@@ -860,9 +860,7 @@ namespace BlenderRenderController
             statusLabel.Update();
 
             if ( !File.Exists(p.blendFilePath) ) {
-                var errors = new List<string>();
-                errors.Add(AppErrorCodes.BLEND_FILE_NOT_EXISTS);
-                Helper.showErrors(errors, MessageBoxIcon.Exclamation);
+                Helper.showErrors(AppErrorCodes.BLEND_FILE_NOT_EXISTS, MessageBoxIcon.Exclamation);
 
                 appSettings.recentBlends.Remove(p.blendFilePath);
                 updateRecentBlendsMenu();
@@ -899,7 +897,7 @@ namespace BlenderRenderController
 			catch( Exception ex ) {
                 _log.Error(ex.ToString());
                 Trace.WriteLine(ex);
-                Helper.showErrors(new List<string> { AppErrorCodes.BLENDER_PATH_NOT_SET });
+                Helper.showErrors(AppErrorCodes.BLENDER_PATH_NOT_SET );
                 settingsForm.ShowDialog();
                 stopRender(false);
                 return;
@@ -980,7 +978,7 @@ namespace BlenderRenderController
                 //notify we are going to render an image
                 if (RenderFormats.IMAGES.Contains(p.renderFormat))
                 {
-                    Helper.showErrors(new List<string> { AppErrorCodes.RENDER_FORMAT_IS_IMAGE }, MessageBoxIcon.Asterisk, p.renderFormat);
+                    Helper.showErrors(AppErrorCodes.RENDER_FORMAT_IS_IMAGE, MessageBoxIcon.Asterisk, p.renderFormat);
                 }
 
                 //FIX RELATIVE RENDER OUTPUT PATHS
@@ -1109,7 +1107,7 @@ namespace BlenderRenderController
             catch (Exception ex)
             {
                 Trace.WriteLine(ex);
-                Helper.showErrors(new List<string> { AppErrorCodes.FFMPEG_PATH_NOT_SET });
+                Helper.showErrors(AppErrorCodes.FFMPEG_PATH_NOT_SET);
                 settingsForm.ShowDialog();
                 statusLabel.Text = "Mixdown cancelled.";
                 return;

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ VSE is pretty good for editing videos, it's precise and relatively easy to learn
 
 This tool offers a work-around for this limitation until the Blender developers make a better renderer for VSE. 
 
-It renders a different segments (chunks) of the project at the same time by multiple blender.exe instances, **making use of full processing power of your PC**.
-After all parts are rendered, they're joined together in FFmpeg, your **video is ready much faster** then previously possible.
+It renders different segments (chunks) of the project at the same time by calling multiple blender.exe instances, **making use of full processing power of your PC**.
+After all parts are rendered, they're joined together in FFmpeg, and your **video is ready much faster** then previously possible.
 
 ### Video demonstration
 [<img src="https://github.com/jendabek/BlenderRenderController/blob/master/BlenderRenderController/extras/intro-720.png" width="480"/>](https://www.youtube.com/watch?v=Kdvq1CzOPfM)
@@ -33,12 +33,12 @@ Even if you don't use Blender VSE often, that’s a LOT of time saved. And the t
 
 ### Dependencies
 - Blender, obviously.
-- [FFmpeg](https://ffmpeg.zeranoe.com/builds/), required for joining the parts together. You don't need to care about it if you download the Full version which has FFmpeg already included.
+- [FFmpeg](https://ffmpeg.zeranoe.com/builds/), required for joining the parts together. You don't need to worry about it if you download the Full version which has FFmpeg already included.
 - .NET framework 4.5
 
 
 ### Steps
-1. Create your Blender VSE project normally within the Blender.
+1. Create your Blender VSE project normally within Blender.
  
 2. Open BlenderRenderController, browse for the .blend file.
  


### PR DESCRIPTION
- `Helper.showErrors` can now take a single error code directly, w/o the need to make a List.
- StreamOutput of `get_project_info` is now stored in a List, just like StreamErrors.
- Fixed some typos in README